### PR TITLE
Fix panic in initialized event

### DIFF
--- a/dap-types/src/events.rs
+++ b/dap-types/src/events.rs
@@ -23,7 +23,7 @@ pub enum Initialized {}
 
 impl Event for Initialized {
     const EVENT: &'static str = "initialized";
-    type Body = ();
+    type Body = Option<crate::Capabilities>;
 }
 
 /// The event indicates that the execution of the debuggee has stopped due to some condition.

--- a/dap-types/src/types.rs
+++ b/dap-types/src/types.rs
@@ -3086,9 +3086,6 @@ pub enum BreakpointModeApplicability {
 }
 
 #[derive(PartialEq, Eq, Debug, Hash, Clone, Deserialize, Serialize)]
-pub struct ThreadId(pub u64);
-
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ModuleId {
     Number(u32),

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -142,8 +142,15 @@ fn write_events(types: &[ProtocolType]) -> String {
             continue;
         }
         let name = o.find_field("event").unwrap().ty.as_enum().single_value();
+
         let body = match &o.find_field("body").unwrap().ty {
-            Type::Any => "()".to_owned(),
+            Type::Any => {
+                if name == "initialized" {
+                    format!("Option<crate::Capabilities>")
+                } else {
+                    "()".to_owned()
+                }
+            }
             Type::Basic(args) => format!("crate::{args}"),
             Type::Object(_) => format!("crate::{}", ty.name),
             _ => panic!("bad body type for {}", ty.name),


### PR DESCRIPTION
This PR fixes the following panic:

```log
crates/dap/src/transport.rs:89: invalid type: map, expected unit variant Events::Initialized
```
Some debug adapter like `vscode-js-debug` send an empty body or send capabilities back. So we have to make sure we can act on this and support older implementation versions of the debug adapter protocol.

**Event**
```
{\"seq\":2,\"type\":\"event\",\"event\":\"initialized\",\"body\":{}}
``` 


**Note**
I also removed the **ThreadId** struct for now, because my idea was to replace it instead of using **u16**. But this is more work than I though, so for now it's fine to just use the **u16**.