### PR TITLE
Add an unknown case for the StackFramePresentationHint enum

### DIFF
--- a/dap-types/src/types.rs
+++ b/dap-types/src/types.rs
@@ -2112,6 +2112,8 @@ pub enum SourcePresentationHint {
     Emphasize,
     #[serde(rename = "deemphasize")]
     Deemphasize,
+    #[serde(other)]
+    Unknown,
 }
 
 /// A Stackframe contains the source location.

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -635,8 +635,14 @@ impl Enum {
         if !self.exhaustive {
             dst.line("#[non_exhaustive]");
         }
+
+        let mut exhaustive = self.exhaustive;
         dst.line(format!("pub enum {} {{", name));
         for (i, value) in self.variants.iter().enumerate() {
+            if name == "SourcePresentationHint" {
+                exhaustive = false;
+            }
+
             if let Some(desc) = &self.variant_descriptions {
                 assert!(desc.len() == self.variants.len());
                 dst.indented_doc(&desc[i]);
@@ -644,7 +650,7 @@ impl Enum {
             dst.indented(format!("#[serde(rename = \"{value}\")]"));
             dst.indented(format!("{},", to_pascal_case(value)));
         }
-        if !self.exhaustive {
+        if !exhaustive {
             dst.indented("#[serde(other)]");
             dst.indented("Unknown,");
         }


### PR DESCRIPTION
This PR adds an unknown version for the **StackFramePresentationHint** enum.

I got stuck on this error while working on making the JavaScript debugger work.

```log
unknown variant `deemphasize`, expected one of `normal`, `label`, `subtle`
```