### PR TITLE
Add other case for all PresentationHint enums

### DIFF
--- a/dap-types/src/types.rs
+++ b/dap-types/src/types.rs
@@ -2180,6 +2180,8 @@ pub enum StackFramePresentationHint {
     Label,
     #[serde(rename = "subtle")]
     Subtle,
+    #[serde(other)]
+    Unknown,
 }
 
 /// A `Scope` is a named container for variables. Optionally a scope can map to a source or a range within a source.
@@ -3076,6 +3078,8 @@ pub enum DisassembledInstructionPresentationHint {
     Normal,
     #[serde(rename = "invalid")]
     Invalid,
+    #[serde(other)]
+    Unknown,
 }
 
 /// Logical areas that can be invalidated by the `invalidated` event.

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -645,12 +645,7 @@ impl Enum {
             dst.indented(format!("#[serde(rename = \"{value}\")]"));
             dst.indented(format!("{},", to_pascal_case(value)));
         }
-        let exhaustive = if name == "SourcePresentationHint" {
-            false
-        } else {
-            self.exhaustive
-        };
-        if !exhaustive {
+        if !self.exhaustive || name.ends_with("PresentationHint") {
             dst.indented("#[serde(other)]");
             dst.indented("Unknown,");
         }


### PR DESCRIPTION
This fixes in issue with denormalizing, because we are getting unsupported values.