### PR TITLE
Make OtherEvent fields public

### DIFF
--- a/dap-types/src/messages.rs
+++ b/dap-types/src/messages.rs
@@ -36,8 +36,8 @@ pub struct Response {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct OtherEvent {
-    event: String,
-    body: Value,
+    pub event: String,
+    pub body: Value,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
While I was trying to debug a Python issue, I noticed that we (me) forgot to make the fields public.