### PR TITLE
Add the `deemphasize` option to the `StackFramePresentationHint` enum.

### DIFF
--- a/dap-types/src/types.rs
+++ b/dap-types/src/types.rs
@@ -2181,6 +2181,8 @@ pub enum StackFramePresentationHint {
     Label,
     #[serde(rename = "subtle")]
     Subtle,
+    #[serde(rename = "deemphasize")]
+    Deemphasize,
     #[serde(other)]
     Unknown,
 }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -646,6 +646,10 @@ impl Enum {
             dst.indented(format!("#[serde(rename = \"{value}\")]"));
             dst.indented(format!("{},", to_pascal_case(value)));
         }
+        if name.ends_with("StackFramePresentationHint") {
+            dst.indented(format!("#[serde(rename = \"deemphasize\")]"));
+            dst.indented("Deemphasize,");
+        }
         if !self.exhaustive || name.ends_with("PresentationHint") {
             dst.indented("#[serde(other)]");
             dst.indented("Unknown,");


### PR DESCRIPTION
Even though the `deemphasize` option is not an official option, we should still add it, because it is a common presentation hint for stack frames. If we add this, we can add support for collapsed stack frames which improved the visibility of the stack frame list.